### PR TITLE
Fix warning about fill-rule and clip-rule

### DIFF
--- a/src/app/ui/DashboardHeader.tsx
+++ b/src/app/ui/DashboardHeader.tsx
@@ -27,9 +27,9 @@ export default function DashboardHeader() {
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  fill-rule="evenodd"
+                  fillRule="evenodd"
                   d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                  clip-rule="evenodd"
+                  clipRule="evenodd"
                 ></path>
               </svg>
             </div>


### PR DESCRIPTION
[Description]
I've been seeing warnings in the console about the fill-rule and clip-rule attributes. Since we are using React, we need to change these attributes to fillRule and clipRule respectively.

[Changes]
- Replace fill-rule and clip-rule with fillRule and clipRule

CU: https://app.clickup.com/t/86cvg00p6