### PR TITLE
Fix cover object-fit issue in Safari in iOS

### DIFF
--- a/src/app/ui/HeroCover.tsx
+++ b/src/app/ui/HeroCover.tsx
@@ -8,9 +8,9 @@ const HeroCover = () => {
   const [hasVideoEnded, setHasVideoEnded] = useState(false);
 
   return (
-    <section className="flex aspect-video min-h-[calc(100vh_-_60px)] w-full flex-col items-center justify-center overflow-hidden">
+    <section className="flex aspect-video max-h-[calc(100dvh_-_60px)] min-h-[calc(100dvh_-_60px)] w-full flex-col items-center justify-center overflow-hidden bg-yellow-100">
       <video
-        className="object-cover [block-size:100%] [inline-size:100%]"
+        className="min-h-dvh w-full object-cover [block-size:100%] [inline-size:100%]"
         preload="none"
         autoPlay
         muted
@@ -23,7 +23,7 @@ const HeroCover = () => {
       {hasVideoEnded && (
         <Link
           href="#amenities"
-          className="absolute bottom-16 flex animate-pulse items-center rounded-full bg-yellow-300 p-2 px-4 drop-shadow-lg [animation-iteration-count:3]"
+          className="absolute bottom-16 flex animate-pulse items-center rounded-full bg-yellow-300 p-2 px-4 drop-shadow-lg [animation-duration:1000ms] [animation-iteration-count:3]"
         >
           <ChevronDoubleDownIcon className="size-6 animate-bounce" />
           <span>Explore Tagparak</span>


### PR DESCRIPTION
[Description]
object-fit:cover does not work on Safari in iOS.

[Cause]
Based on my research, it seems that Safari fails to calculate the media's true dimension when its height/width is in percentage.

[Fix]
Use a viewport unit.

[Additional changes]
- Shorten the pulse animation duration
- Add a background color to the hero cover section in case the hero cover does not load immediately

CU: https://app.clickup.com/t/86cxuk5qd