### PR TITLE
Fix menu and maps overlap in location page

### DIFF
--- a/src/app/ui/Header.tsx
+++ b/src/app/ui/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
     <>
       <Disclosure
         as="nav"
-        className="absolute z-10 w-full bg-white drop-shadow-lg"
+        className="absolute z-50 w-full bg-white drop-shadow-lg"
       >
         {({ open }) => (
           <>


### PR DESCRIPTION
[Description]
The dropdown menu is behind the maps in the location page.

[Cause]
The maps component has higher z-index than the dropdown menu.

[Fix]
Bump the z-index of the menu.

[Preview]

Before

![Screenshot 2025-02-21 at 4 54 55 PM](https://github.com/user-attachments/assets/ccfed08e-e767-4082-bfcd-a6332329c04a)

After

![Screenshot 2025-02-21 at 4 55 09 PM](https://github.com/user-attachments/assets/17d5a31c-c26c-432b-8aa3-afdf71c79661)

CU: https://app.clickup.com/t/86cxv85x4