### PR TITLE
Fix: Background height issue on smaller viewports

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function Page() {
 
         {/* Customer Reviews */}
         <section id="reviews" className="relative min-h-dvh w-full bg-blue-400">
-          <div className="inset-shadow-[800px_0_100px_0_oklch(0.623 0.214 259.815)] max-h-dvh min-h-dvh w-full bg-[url('/images/tagparak-customer-reviews-background.jpg')] bg-cover bg-[center_70%]"></div>
+          <div className="absolute bottom-0 left-0 left-0 right-0 top-0 top-0 m-auto min-h-dvh bg-[url('/images/tagparak-customer-reviews-background.jpg')] bg-cover bg-[center_70%]"></div>
           <CustomerReviews reviews={reviews} />
         </section>
 

--- a/src/app/ui/CustomerReviews.tsx
+++ b/src/app/ui/CustomerReviews.tsx
@@ -33,8 +33,8 @@ const CustomerReviews = ({ reviews }: { reviews: QueryResultRow[] }) => {
   }, []);
 
   return (
-    <div className="absolute bottom-0 left-0 right-0 top-0 z-10 m-auto flex items-center justify-center lg:right-1/3">
-      <div className="aspect-3/2 flex max-h-full max-w-full flex-col items-center justify-center gap-2 bg-white bg-opacity-50 p-6 lg:max-h-[50%] lg:max-w-[60%]">
+    <div className="relative min-h-dvh">
+      <div className="flex h-full min-h-dvh flex-col items-center justify-center gap-2 bg-white bg-opacity-50 p-6 xl:absolute xl:left-[20%] xl:top-1/2 xl:aspect-[3/2] xl:max-h-[50%] xl:min-h-0 xl:-translate-y-[50%]">
         <Image
           src="/icons/review.svg"
           alt="Tagparak - beach icon"


### PR DESCRIPTION
[Description]
If the height of the device is smaller than the height of the customer reviews container, it overflows.

[Cause]
The customer review container has the absolute position, which means that it is disregarded when computing the height of the section background.

[Fix]
Only set the the position to absolute on XL screens.